### PR TITLE
Update SharedFile.py

### DIFF
--- a/pybacklogpy/SharedFile.py
+++ b/pybacklogpy/SharedFile.py
@@ -41,8 +41,8 @@ class SharedFile:
         if offset is not None:
             payloads['offset'] = offset
         if count is not None:
-            if not 1 <= count <= 100:
-                raise ValueError('count(取得上限)は1-100の範囲で指定してください')
+            if not 1 <= count <= 1000:
+                raise ValueError('count(取得上限)は1-1000の範囲で指定してください')
 
         return self.rs.send_get_request(path=path, url_param=payloads)
 


### PR DESCRIPTION
バリデーションチェック不正の修正

https://developer.nulab.com/ja/docs/backlog/api/2/get-list-of-shared-files/#クエリパラメーター
> count	数値	取得上限(1-1000) 指定が無い場合は1000