### PR TITLE
fix get_list_of_project_administrators method

### DIFF
--- a/pybacklogpy/Project.py
+++ b/pybacklogpy/Project.py
@@ -260,7 +260,7 @@ class Project:
 
         path = self.base_path + '/{project_id_or_key}/administrators'.format(project_id_or_key=project_id_or_key)
 
-        return self.rs.send_delete_request(path=path, request_param={})
+        return self.rs.send_get_request(path=path, request_param={})
 
     def delete_project_user(self,
                             project_id_or_key: str,


### PR DESCRIPTION
プロジェクト管理者一覧の取得 でdelete が指定されているため取得に失敗します。